### PR TITLE
Add support for C++20.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,11 @@ else ()
     include(CheckCXXCompilerFlag)
     CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
     CHECK_CXX_COMPILER_FLAG("-std=c++17" COMPILER_SUPPORTS_CXX17)
+    CHECK_CXX_COMPILER_FLAG("-std=c++20" COMPILER_SUPPORTS_CXX20)
 
     # check gcc version
+    set(CMAKE_CXX_STANDARD 20)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
     if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
         if ("${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS 9)
@@ -31,7 +34,9 @@ else ()
         endif ()
     endif ()
 
-    if (COMPILER_SUPPORTS_CXX17)
+    if (COMPILER_SUPPORTS_CXX20)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++20")
+    elseif (COMPILER_SUPPORTS_CXX17)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
     elseif (COMPILER_SUPPORTS_CXX11)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")

--- a/src/core/parser.cpp
+++ b/src/core/parser.cpp
@@ -952,7 +952,7 @@ sptr<Atom> TeXParser::convertCharacter(wchar_t c, bool oneChar) {
     const UnicodeBlock& block = UnicodeBlock::of(c);
 #ifdef HAVE_LOG
     int idx = indexOf(DefaultTeXFont::_loadedAlphabets, block);
-    __log << "block of char: " << c << " is " << idx << endl;
+    __log << "block of char: " << std::to_string(c) << " is " << idx << endl;
 #endif  // HAVE_LOG
     bool exist = (indexOf(DefaultTeXFont::_loadedAlphabets, block) != -1);
     if (!_isLoading && !exist) {

--- a/src/fonts/font_basic.cpp
+++ b/src/fonts/font_basic.cpp
@@ -15,7 +15,7 @@ Extension::~Extension() {
 #ifdef HAVE_LOG
 namespace tex {
 std::ostream& operator<<(std::ostream& os, const CharFont& font) {
-  os << "CharFont { char: " << font.chr
+  os << "CharFont { char: " << std::to_string(font.chr)
      << ", font: " << font.fontId
      << ", bold font: " << font.boldFontId
      << " }";

--- a/src/fonts/font_info.cpp
+++ b/src/fonts/font_info.cpp
@@ -71,6 +71,7 @@ void FontInfo::__free() {
 
 #ifdef HAVE_LOG
 #include <iomanip>
+#include <codecvt>
 namespace tex {
     ostream& operator<<(ostream& os, const FontInfo& info) {
         // base information
@@ -90,10 +91,16 @@ namespace tex {
             const int rows = info._lig.rows();
             for (int i = 0; i < rows; i++) {
                 const wchar_t* t = info._lig[i];
+                std::wstring _a(t);
+                std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
+                std::string _b{};
+                try{_b = converter.to_bytes(_a);}
+                catch (const std::range_error& e)
+                { _b = "�";}
                 os << "\t["
-                    << setw(3) << t[0] << ", "
-                    << setw(3) << t[1] << "] = "
-                    << t[2] << endl;
+                    << setw(3) << _b[0] << ", "
+                    << setw(3) << _b[1] << "] = "
+                    << _b[2] << endl;
             }
         }
 

--- a/src/latex.cpp
+++ b/src/latex.cpp
@@ -59,7 +59,7 @@ string LaTeX::queryResourceLocation(string& custom_path) {
     p.append(CHECK_FILE);
     if (filesystem::exists(p)) {
       p.remove_filename();
-      return p.u8string();
+      return p.string();
     }
 #elif defined(_MSC_VER)
     std::string path = paths.front();


### PR DESCRIPTION
1. Tweak CMakeLists.txt to use C++20.
2. Add std::to_string(fmt.chr) for wide character font output.
3. Add codecvt call to convert wstring to string where needed.

Closes https://github.com/NanoMichael/MicroTeX/issues/136