### PR TITLE
Fix latex2png. C++20 compatibility. Add static build of microlatex-qt

### DIFF
--- a/example/qtpng/latex2png.cpp
+++ b/example/qtpng/latex2png.cpp
@@ -17,7 +17,7 @@
 class TexGuard {
 public:
   TexGuard(const microtex::FontSrc& math) {
-    microtex::MicroTeX::init(&math);
+    microtex::MicroTeX::init(math);
     microtex::PlatformFactory::registerFactory("qt", std::make_unique<microtex::PlatformFactory_qt>());
     microtex::PlatformFactory::activate("qt");
   }

--- a/lib/core/formula_def.cpp
+++ b/lib/core/formula_def.cpp
@@ -118,7 +118,11 @@ map<string, string> Formula::_predefFormulaStrs{
   {"Rho",              "Ρ"},
   {"Tau",              "Τ"},
   {"Chi",              "Χ"},
-  {"Nabla",            u8"\u2207"}, // win32 compat, ugly
+#if defined(WIN32)
+    {"Nabla", u8"\u2207"},  // win32 compat, ugly
+#else
+    {"Nabla", "\u2207"},
+#endif
   {"omicron",          "ο"},
   // endregion
   // region colons

--- a/lib/utils/dict_tree.h
+++ b/lib/utils/dict_tree.h
@@ -61,7 +61,7 @@ public:
     return !(*this == b);
   }
 
-  ~SortedDictTree<K, V>() {
+  ~SortedDictTree() {
     for (u16 i = 0; i < _childCount; i++) delete _children[i];
     delete[] _children;
   }

--- a/platform/qt/CMakeLists.txt
+++ b/platform/qt/CMakeLists.txt
@@ -1,6 +1,13 @@
 message(STATUS "Cross-building using Qt")
 
-add_library(microtex-qt SHARED graphic_qt.cpp)
+set(MICROTEX_QT_sources "graphic_qt.cpp")
+if (DEFINED _BUILD_STATIC AND _BUILD_STATIC)
+    add_library(microtex-qt STATIC  "${MICROTEX_QT_sources}")
+else ()
+    add_library(microtex-qt SHARED  "${MICROTEX_QT_sources}")
+endif ()
+
+#add_library(microtex-qt SHARED graphic_qt.cpp)
 
 set_target_properties(
     microtex-qt PROPERTIES


### PR DESCRIPTION
1. Fix small bug in latex2png initialization.
2. Fix small c++20 incompatibilities.
3. Build microlatex-qt as a static library if microlatex is built as a static library.
