### PR TITLE
unimath: added \emptyset symbol

### DIFF
--- a/lib/unimath/uni_symbol.cpp
+++ b/lib/unimath/uni_symbol.cpp
@@ -2812,7 +2812,7 @@ const Symbol _symbols[]{
   {0x022BF, ord,     "varlrtriangle"},
   {0x022FD, rel,     "varniobar"},
   {0x022FB, rel,     "varnis"},
-  {0x02205, ord,     "varnothing"},
+  {0x02300, ord,     "varnothing"},
   {0x02232, opt | N, "varointclockwise"},
   {0x003C6, ord,     "varphi"},
   {0x003C6, ord,     "varphiup"},

--- a/lib/unimath/uni_symbol.cpp
+++ b/lib/unimath/uni_symbol.cpp
@@ -673,6 +673,7 @@ const Symbol _symbols[]{
   {0x023E7, ord,     "elinters"},
   {0x02113, ord,     "ell"},
   {0x02A97, rel,     "elsdot"},
+  {0x02205, ord,     "emptyset"},
   {0x029B3, ord,     "emptysetoarr"},
   {0x029B4, ord,     "emptysetoarrl"},
   {0x029B1, ord,     "emptysetobar"},


### PR DESCRIPTION
MicroTeX should now render ![Bildschirmfoto vom 2023-06-16 08-54-13](https://github.com/NanoMichael/MicroTeX/assets/31540351/0d281430-82f5-4c5f-a8ba-d5279f43356a) when it receives \emptyset.

~~`\varnothing` currently also renders the same character (U+2205), it might be useful to make behave like TeX and cLaTeXMath and let it render ![Bildschirmfoto vom 2023-06-16 08-55-59](https://github.com/NanoMichael/MicroTeX/assets/31540351/7b20d417-7e43-4fc8-9b68-75144a0dfbc8), however I don't think unicode differentiates between them (maybe draw it in code? a circle and a line should be simple enough).~~

closes #138 
