### PR TITLE
Added support for building wasm from meson

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -65,13 +65,28 @@ jobs:
     steps:
       - name: Downloading Source Code 📥
         uses: actions/checkout@v2
+      - name: Downloading dependencies 📥
+        run: |
+          sudo apt-get install ninja-build
+          sudo pip3 install meson # meson provided by ubuntu is too old. can be removed when ubunut-latest swiches to 24.04
       - name: Setup Emscripten Environment 🍺
         uses: mymindstorm/setup-emsdk@v11
       - name: Verify Emscripten 🚀
         run: emcc -v
-      - name: Compile 🎲
+      - name: Compile using CMake 🎲
         run: |
           cd ${{ github.workspace }}
           cd platform/wasm/web
           npm install
           npm run build:lib && npm run build:example
+      - name: Compile using Meson 🎲
+        run: |
+          cd ${{ github.workspace }}
+          cd platform/wasm/web
+          npm install
+          npm run build:lib:meson && npm run build:example:meson
+      - name: Upload build artifacts 📤
+        uses: actions/upload-artifact@v1
+        with:
+          name: MicroTeX wasm example
+          path: platform/wasm/web/example-dist

--- a/lib/wrapper/meson.build
+++ b/lib/wrapper/meson.build
@@ -1,0 +1,22 @@
+cwrapper_src = [
+	'byte_seq.cpp',
+	'callback.cpp',
+	'cwrapper.cpp',
+	'graphic_wrapper.cpp'
+]
+
+microtex_cwrapper_lib = library('microtex-cwrapper', cwrapper_src,
+	link_with: microtex_lib,
+	include_directories: inc,
+	cpp_args: ['-DHAVE_CWRAPPER'],
+	version: meson.project_version(),
+	soversion: microtex_api_version,
+	install: false
+)
+
+microtex_cwrapper_dep = declare_dependency(
+	link_with: [microtex_lib, microtex_cwrapper_lib],
+	include_directories: ['.', inc],
+	compile_args: ['-DHAVE_CWRAPPER'],
+	version: meson.project_version()
+)

--- a/meson.build
+++ b/meson.build
@@ -62,6 +62,10 @@ else
   endif
 endif
 
+if cpp.get_id() == 'emscripten'
+  subdir('platform/wasm')
+endif
+
 if get_option('TEST')
     subdir('test')
 endif

--- a/platform/wasm/emscripten.cross
+++ b/platform/wasm/emscripten.cross
@@ -8,6 +8,8 @@ exe_wrapper = 'node'
 
 [built-in options]
 default_library = 'static'
+cpp_args = '-fexceptions -sNO_DISABLE_EXCEPTION_CATCHING'
+cpp_link_args = '-fexceptions -sNO_DISABLE_EXCEPTION_CATCHING'
 
 [project options]
 CAIRO = false

--- a/platform/wasm/emscripten.cross
+++ b/platform/wasm/emscripten.cross
@@ -1,0 +1,29 @@
+; Taken from https://github.com/videolan/dav1d/blob/master/package/crossfiles/wasm64.meson
+[binaries]
+c = 'emcc'
+cpp = 'em++'
+ar = 'emar'
+strip = 'emstrip'
+exe_wrapper = 'node'
+
+[built-in options]
+default_library = 'static'
+
+[project options]
+CAIRO = false
+EXAMPLE_GTKMM = false
+
+GTK = false
+EXAMPLE_GTK = false
+
+QT = false
+EXAMPLE_QT = false
+
+GDI = 'disabled'
+EXAMPLE_WIN32 = false
+
+[host_machine]
+system = 'emscripten'
+cpu_family = 'wasm64'
+cpu = 'wasm64'
+endian = 'little'

--- a/platform/wasm/meson.build
+++ b/platform/wasm/meson.build
@@ -2,9 +2,7 @@ subdir('lib/wrapper')
 
 executable('microtex-wasm', 'main.cpp',
 	dependencies: [microtex_dep, microtex_cwrapper_dep],
-	link_args: ['-fexceptions', '-sMODULARIZE=1', '-sEXPORT_ES6=1', '-sWASM=1',
-		'-sEXPORTED_RUNTIME_METHODS=allocateUTF8,UTF8ToString,addFunction',
-		'-sEXPORTED_FUNCTIONS=_malloc,_free', '-sIMPORTED_MEMORY',
-		'-sALLOW_MEMORY_GROWTH=1', '-sRESERVED_FUNCTION_POINTERS=4'
+	link_args: ['-sMODULARIZE=1', '-sEXPORT_ES6=1', '-sWASM=1', '-sEXPORTED_RUNTIME_METHODS=allocateUTF8,UTF8ToString,addFunction',
+		'-sEXPORTED_FUNCTIONS=_malloc,_free', '-sIMPORTED_MEMORY', '-sALLOW_MEMORY_GROWTH=1', '-sRESERVED_FUNCTION_POINTERS=4'
 	]
 )

--- a/platform/wasm/meson.build
+++ b/platform/wasm/meson.build
@@ -1,0 +1,10 @@
+subdir('lib/wrapper')
+
+executable('microtex-wasm', 'main.cpp',
+	dependencies: [microtex_dep, microtex_cwrapper_dep],
+	link_args: ['-fexceptions', '-sMODULARIZE=1', '-sEXPORT_ES6=1', '-sWASM=1',
+		'-sEXPORTED_RUNTIME_METHODS=allocateUTF8,UTF8ToString,addFunction',
+		'-sEXPORTED_FUNCTIONS=_malloc,_free', '-sIMPORTED_MEMORY',
+		'-sALLOW_MEMORY_GROWTH=1', '-sRESERVED_FUNCTION_POINTERS=4'
+	]
+)

--- a/platform/wasm/prebuild-example-meson.sh
+++ b/platform/wasm/prebuild-example-meson.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+
+set -e
+
+web_dir="$(pwd)"
+
+cd .. || return
+build_dir="$(pwd)/_build"
+
+# go to project root dir
+cd ../../
+project_dir=$(pwd)
+
+rm -rf "${web_dir}/example-dist"
+mkdir "${web_dir}/example-dist"
+
+# copy to example
+cp -r "${project_dir}/res" "${web_dir}/example-dist"
+cp "${build_dir}/platform/wasm/microtex-wasm.wasm" "${web_dir}/example-dist"
+cp "${web_dir}/example/index.html" "${web_dir}/example-dist"
+cp "${web_dir}/example/styles.css" "${web_dir}/example-dist"

--- a/platform/wasm/prebuild-lib-meson.sh
+++ b/platform/wasm/prebuild-lib-meson.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/sh
+
+set -e
+
+web_dir="$(pwd)"
+
+cd .. || return
+build_dir="$(pwd)/_build"
+
+if [ -d "${build_dir}" ]; then
+	/bin/rm -r "${build_dir}"
+fi
+
+meson setup --buildtype=release --cross-file emscripten.cross "${build_dir}" ../../
+ninja -C "${build_dir}"
+
+rm -rf "${web_dir}/dist"
+rm -rf "${web_dir}/gen"
+
+mkdir "${web_dir}/gen"
+mkdir "${web_dir}/dist"
+
+# copy to gen
+cp "${build_dir}/platform/wasm/microtex-wasm.wasm" "${web_dir}/gen"
+cp "${build_dir}/platform/wasm/microtex-wasm.js" "${web_dir}/gen"
+
+# copy to dist
+cp "${build_dir}/platform/wasm/microtex-wasm.wasm" "${web_dir}/dist"

--- a/platform/wasm/web/lib/context.js
+++ b/platform/wasm/web/lib/context.js
@@ -142,6 +142,9 @@ context.init = function (clmDataUri) {
   return initRuntime()
     .then(r => _runtime = r)
     .then(_ => {
+      _runtime._microtex_setRenderGlyphUsePath(true);
+    })
+    .then(_ => {
       const a = _runtime.addFunction(createTextLayout, 'iii');
       const b = _runtime.addFunction(getTextLayoutBounds, 'vii');
       const c = _runtime.addFunction(releaseTextLayout, 'vi');

--- a/platform/wasm/web/package-lock.json
+++ b/platform/wasm/web/package-lock.json
@@ -2138,7 +2138,7 @@
     },
     "node_modules/core-js": {
       "version": "3.31.0",
-      "resolved": "http://bnpm.byted.org/core-js/-/core-js-3.31.0.tgz",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.31.0.tgz",
       "integrity": "sha512-NIp2TQSGfR6ba5aalZD+ZQ1fSxGhDo/s1w0nx3RYzf2pnJxt7YynxFlFScP6eV7+GZsKO95NSjGxyJsU3DZgeQ==",
       "hasInstallScript": true,
       "license": "MIT",
@@ -2987,7 +2987,7 @@
     },
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
-      "resolved": "http://bnpm.byted.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
       "license": "MIT"
     },
@@ -4974,7 +4974,7 @@
     },
     "core-js": {
       "version": "3.31.0",
-      "resolved": "http://bnpm.byted.org/core-js/-/core-js-3.31.0.tgz",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.31.0.tgz",
       "integrity": "sha512-NIp2TQSGfR6ba5aalZD+ZQ1fSxGhDo/s1w0nx3RYzf2pnJxt7YynxFlFScP6eV7+GZsKO95NSjGxyJsU3DZgeQ=="
     },
     "core-js-compat": {
@@ -5592,7 +5592,7 @@
     },
     "regenerator-runtime": {
       "version": "0.13.11",
-      "resolved": "http://bnpm.byted.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "regenerator-transform": {

--- a/platform/wasm/web/package.json
+++ b/platform/wasm/web/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build:lib": "sh ../prebuild-lib.sh && rollup --config rollup.config.lib.js",
-    "build:example": "sh ../prebuild-example.sh && rollup --config rollup.config.example.js"
+    "build:lib:meson": "sh ../prebuild-lib-meson.sh && rollup --config rollup.config.lib.js",
+    "build:example": "sh ../prebuild-example.sh && rollup --config rollup.config.example.js",
+    "build:example:meson": "sh ../prebuild-example-meson.sh && rollup --config rollup.config.example.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
For some reason, when using the meson built microtex-wasm.wasm it initially starts to throw a few `microtex::ex_parse: Missing '['!` and `microtex::ex_parse: Missing '{'!` when switching rendering mode that don't occur with cmake. But since wasm seems impossible to debug, I didn't look into it further.

Also replaced a mirror that seems to be only resolvable in mainland china with the normal npmjs registry, as npm just hangs otherwise and it'll fail eventually (also using http instead of https 😬 ).