### PR TITLE
Another large set of fuzzer fixes

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -29,6 +29,7 @@ endif ()
 set(
     _SRCS
     # atom folder
+    atom/atom.cpp
     atom/atom_basic.cpp
     atom/atom_char.cpp
     atom/atom_misc.cpp

--- a/lib/atom/atom.cpp
+++ b/lib/atom/atom.cpp
@@ -1,0 +1,14 @@
+#include "atom/atom.h"
+#include "atom/atom_basic.h"
+
+using namespace microtex;
+
+WrapAtom::WrapAtom(const sptr<Atom>& base) {
+    if (base) {
+      _type = base->_type;
+      _base = base;
+    } else {
+      _type = AtomType::ordinary;
+      _base = sptrOf<EmptyAtom>();
+    }
+}

--- a/lib/atom/atom.h
+++ b/lib/atom/atom.h
@@ -78,9 +78,7 @@ protected:
   sptr<Atom> _base;
 
 public:
-  explicit WrapAtom(const sptr<Atom>& base) : _base(base) {
-    _type = base == nullptr ? AtomType::ordinary : base->_type;
-  }
+  explicit WrapAtom(const sptr<Atom>& base);
 
   inline sptr<Atom> base() const { return _base; }
 

--- a/lib/atom/atom_delim.h
+++ b/lib/atom/atom_delim.h
@@ -4,6 +4,7 @@
 #include <utility>
 
 #include "atom/atom.h"
+#include "atom/atom_basic.h"
 #include "atom/atom_char.h"
 #include "atom/atom_space.h"
 
@@ -39,7 +40,8 @@ public:
   OverUnderDelimiter() = delete;
 
   OverUnderDelimiter(const sptr<Atom>& base, std::string delim, bool over)
-      : _base(base), _delim(std::move(delim)), _over(over) {
+      : _delim(std::move(delim)), _over(over) {
+    _base = base == nullptr ? sptrOf<EmptyAtom>() : base;
     _type = AtomType::inner;
     _limitsType = LimitsType::limits;
   }

--- a/lib/atom/atom_misc.cpp
+++ b/lib/atom/atom_misc.cpp
@@ -16,6 +16,10 @@ sptr<Box> BigSymbolAtom::createBox(Env& env) {
   return sptrOf<HBox>(b);
 }
 
+LapedAtom::LapedAtom(const sptr<Atom>& a, char type) : _type(type) {
+	_at = a == nullptr ? sptrOf<EmptyAtom>() : a;
+}
+
 sptr<Box> LapedAtom::createBox(Env& env) {
   auto b = _at->createBox(env);
   auto* vb = new VBox();

--- a/lib/atom/atom_misc.cpp
+++ b/lib/atom/atom_misc.cpp
@@ -68,8 +68,8 @@ sptr<Box> ResizeAtom::createBox(Env& env) {
 
 RotateAtom::RotateAtom(const sptr<Atom>& base, float angle, const string& option)
     : _angle(0), _option(Rotation::bl) {
-  _type = base->_type;
-  _base = base;
+  _base = base == nullptr ? sptrOf<EmptyAtom>() : base;
+  _type = _base->_type;
   _angle = angle;
   const auto& opt = parseOption(option);
   auto it = opt.find("origin");

--- a/lib/atom/atom_misc.h
+++ b/lib/atom/atom_misc.h
@@ -43,7 +43,7 @@ private:
 public:
   LapedAtom() = delete;
 
-  LapedAtom(const sptr<Atom>& a, char type) : _at(a), _type(type) {}
+  LapedAtom(const sptr<Atom>& a, char type);
 
   sptr<Box> createBox(Env& env) override;
 };

--- a/lib/atom/atom_misc.h
+++ b/lib/atom/atom_misc.h
@@ -2,6 +2,7 @@
 #define MICROTEX_ATOM_MISC_H
 
 #include "atom/atom.h"
+#include "atom/atom_basic.h"
 #include "atom/atom_char.h"
 #include "atom/atom_vrow.h"
 #include "box/box_factory.h"
@@ -94,8 +95,9 @@ public:
     const std::string& hs,
     bool keepAspectRatio
   ) {
-    _type = base->_type;
-    _base = base;
+    const sptr<Atom>& xbase = base == nullptr ? sptrOf<EmptyAtom>() : base;
+    _type = xbase->_type;
+    _base = xbase;
     _keepAspectRatio = keepAspectRatio;
     _width = Units::getDimen(ws);
     _height = Units::getDimen(hs);
@@ -144,7 +146,9 @@ private:
   sptr<Atom> _at;
 
 public:
-  explicit StrikeThroughAtom(const sptr<Atom>& a) : _at(a) {}
+  explicit StrikeThroughAtom(const sptr<Atom>& a) {
+    _at = a == nullptr ? sptrOf<EmptyAtom>() : a;
+  }
 
   sptr<Box> createBox(Env& env) override;
 };

--- a/lib/atom/atom_sideset.cpp
+++ b/lib/atom/atom_sideset.cpp
@@ -7,6 +7,14 @@
 
 using namespace microtex;
 
+SideSetsAtom::SideSetsAtom(const sptr<Atom>& base, const sptr<Atom>& left, const sptr<Atom>& right) {
+  _base = base == nullptr ? sptrOf<EmptyAtom>() : base;
+  _left = left == nullptr ? sptrOf<EmptyAtom>() : left;
+  _right = right == nullptr ? sptrOf<EmptyAtom>() : right;
+  _type = AtomType::bigOperator;
+  _limitsType = LimitsType::noLimits;
+}
+
 sptr<Box> SideSetsAtom::createBox(Env& env) {
   _base->_limitsType = LimitsType::noLimits;
   sptr<Box> l, m, r;

--- a/lib/atom/atom_sideset.h
+++ b/lib/atom/atom_sideset.h
@@ -14,11 +14,7 @@ public:
 
   SideSetsAtom() = delete;
 
-  SideSetsAtom(const sptr<Atom>& base, const sptr<Atom>& left, const sptr<Atom>& right)
-      : _base(base), _left(left), _right(right) {
-    _type = AtomType::bigOperator;
-    _limitsType = LimitsType::noLimits;
-  }
+  SideSetsAtom(const sptr<Atom>& base, const sptr<Atom>& left, const sptr<Atom>& right);
 
   sptr<Box> createBox(Env& env) override;
 };

--- a/lib/atom/atom_zstack.cpp
+++ b/lib/atom/atom_zstack.cpp
@@ -13,8 +13,9 @@ ZStackAtom::ZStackAtom(
     const ZStackArgs& vargs,
     const sptr<Atom>& atom,
     const sptr<Atom>& anchor
-  ) : _hargs(hargs), _vargs(vargs), _anchor(anchor) {
+  ) : _hargs(hargs), _vargs(vargs) {
       _atom = atom == nullptr ? sptrOf<EmptyAtom>() : atom;
+      _anchor = anchor == nullptr ? sptrOf<EmptyAtom>() : anchor;
 }
 
 sptr<Box> ZStackAtom::createBox(Env& env) {

--- a/lib/atom/atom_zstack.cpp
+++ b/lib/atom/atom_zstack.cpp
@@ -1,11 +1,21 @@
 #include "atom/atom_zstack.h"
 
+#include "atom/atom_basic.h"
 #include "box/box_group.h"
 #include "box/box_single.h"
 #include "env/env.h"
 #include "env/units.h"
 
 using namespace microtex;
+
+ZStackAtom::ZStackAtom(
+    const ZStackArgs& hargs,
+    const ZStackArgs& vargs,
+    const sptr<Atom>& atom,
+    const sptr<Atom>& anchor
+  ) : _hargs(hargs), _vargs(vargs), _anchor(anchor) {
+      _atom = atom == nullptr ? sptrOf<EmptyAtom>() : atom;
+}
 
 sptr<Box> ZStackAtom::createBox(Env& env) {
   const auto anchor = _anchor->createBox(env);

--- a/lib/atom/atom_zstack.h
+++ b/lib/atom/atom_zstack.h
@@ -23,8 +23,7 @@ public:
     const ZStackArgs& vargs,
     const sptr<Atom>& atom,
     const sptr<Atom>& anchor
-  )
-      : _hargs(hargs), _vargs(vargs), _atom(atom), _anchor(anchor) {}
+  );
 
   AtomType leftType() const override { return _anchor->leftType(); }
 

--- a/lib/atom/meson.build
+++ b/lib/atom/meson.build
@@ -1,4 +1,5 @@
 atom_src = [
+	'atom/atom.cpp',
 	'atom/atom_accent.cpp',
     'atom/atom_basic.cpp',
     'atom/atom_box.cpp',

--- a/lib/core/formula.cpp
+++ b/lib/core/formula.cpp
@@ -172,3 +172,4 @@ void ArrayFormula::checkDimensions() {
     }
   }
 }
+

--- a/lib/macro/macro_accent.h
+++ b/lib/macro/macro_accent.h
@@ -10,6 +10,8 @@
 namespace microtex {
 
 inline macro(accentset) {
+  if (args[1] == "")
+    return Formula(tp, args[2], false)._root;
   return sptrOf<AccentedAtom>(Formula(tp, args[2], false)._root, args[1].substr(1), false, true);
 }
 

--- a/lib/macro/macro_fonts.cpp
+++ b/lib/macro/macro_fonts.cpp
@@ -23,7 +23,10 @@ macro(intertext) {
 }
 
 macro(addfont) {
-  MicroTeX::addFont(FontSrcFile(args[1], args[2]));
+  if (MicroTeX::isPrivilegedEnvironment())
+    MicroTeX::addFont(FontSrcFile(args[1], args[2]));
+  else
+    throw ex_unprivileged("\\addfont may only be called in privileged environments");
   return nullptr;
 }
 

--- a/lib/microtex.cpp
+++ b/lib/microtex.cpp
@@ -16,6 +16,7 @@ namespace microtex {
 
 struct Config {
   bool isInited;
+  bool isPrivilegedEnvironment;
   std::string defaultMainFontFamily;
   std::string defaultMathFontName;
   bool renderGlyphUsePath;
@@ -23,7 +24,7 @@ struct Config {
   TexStyle overrideTeXStyle;
 };
 
-static Config MICROTEX_CONFIG{false, "", "", false, false, TexStyle::text};
+static Config MICROTEX_CONFIG{false, false, "", "", false, false, TexStyle::text};
 
 } // namespace microtex
 
@@ -71,6 +72,7 @@ FontMeta MicroTeX::init(const Init& init) {
   auto meta = std::visit(InitVisitor(), init);
   _config->defaultMathFontName = meta.name;
   _config->isInited = true;
+  _config->isPrivilegedEnvironment = false;
   NewCommandMacro::_init_();
   return meta;
 }
@@ -86,6 +88,7 @@ FontMeta MicroTeX::init(const FontSrc& mathFontSrc) {
   }
   _config->defaultMathFontName = meta.name;
   _config->isInited = true;
+  _config->isPrivilegedEnvironment = false;
   NewCommandMacro::_init_();
   return meta;
 }
@@ -97,6 +100,14 @@ bool MicroTeX::isInited() {
 void MicroTeX::release() {
   MacroInfo::_free_();
   NewCommandMacro::_free_();
+}
+
+bool MicroTeX::isPrivilegedEnvironment() {
+	return _config->isPrivilegedEnvironment;
+}
+
+void MicroTeX::setPrivilegedEnvironment(bool privileged) {
+	_config->isPrivilegedEnvironment = privileged;
 }
 
 FontMeta MicroTeX::addFont(const FontSrc& src) {

--- a/lib/microtex.h
+++ b/lib/microtex.h
@@ -92,6 +92,29 @@ public:
   /** Check if context is initialized */
   static bool isInited();
 
+  /**
+   * Check if the current setup has privileged execution access.
+   * By default, this is set to false, but can be enabled by calling
+   * ::setPrivilegedEnvironment"("true")".
+   *
+   * @returns true if it has, false otherwise
+   */
+  static bool isPrivilegedEnvironment();
+
+  /**
+   * Set privileged execution access for the current setup.
+   * If privileged access in enabled, TeX macros are allowed
+   * to access the filesystem, invoke external binaries, etc.
+   *
+   * Macros affected by this:
+   * <ul>
+   *  <li>`addfont`</li>
+   * </ul>
+   *
+   * @param privileged whether to allow privileged access or not
+	 */
+  static void setPrivilegedEnvironment(bool privileged);
+
   /** Add a font to context, returns its meta info. */
   static FontMeta addFont(const FontSrc& src);
 

--- a/lib/utils/exceptions.h
+++ b/lib/utils/exceptions.h
@@ -51,6 +51,11 @@ public:
   explicit ex_eof(const std::string& msg) : ex_tex(msg) {}
 };
 
+class ex_unprivileged : public ex_tex {
+public:
+  explicit ex_unprivileged(const std::string& msg) : ex_tex(msg) {}
+};
+
 }  // namespace microtex
 
 #endif

--- a/test/fuzzer/fuzz.sh
+++ b/test/fuzzer/fuzz.sh
@@ -98,6 +98,29 @@ case $1 in
 		"$dir/generateSeed.java" "$project_root/res/SAMPLES.tex" "$seeds_dir"
 		exit 0
 		;;
+	min)
+		echo "Minimizing all crashes..."
+		CRASHDIR="$fuzz_out/default/crashes/"
+		if [ ! -d "$CRASHDIR" ]; then
+			echo "Did not found crash directory at expected location: $CRASHDIR, please run the fuzzer first."
+			exit 1
+		fi
+		MINOUT="$fuzz_out/default/crashes-min/"
+		mkdir -p "$MINOUT"
+		for crash in "$CRASHDIR"/id*; do
+			MICROTEX_FONTDIR="$project_root/res/lm-math/" afl-tmin -i "$crash" -o "$MINOUT"/`basename "$crash"` -- "$build_root/test/fuzzer/microtex-fuzzme"
+		done
+		exit 0
+		;;
+	dbg)
+		if [ -z "$2" ]; then
+			echo "You need to specify the specific crash. ./fuzz.sh [options] dbg <path/to/crashfile>"
+			exit 1
+		fi
+		ninja -C "$build_root"
+		MICROTEX_FONTDIR="$project_root/res/lm-math/" gdb  "$build_root/test/fuzzer/microtex-fuzzme" -ex "run <'$2'"
+		exit 0
+		;;
 	"")
 		;;
 	*)


### PR DESCRIPTION
The following subset of minified crashlogs was used:
```
---
\begin{array}{{{}}}\resizebox0{
---
\sfrac$
---
\underbrace\newcolumntype
---
\begin{array}|\stackinset{}{}{}{
---
\accentset
---

\st\newcolumntype
---
\begin{split}\rotatebox{{{
---
\sideset$
---
```


There are a few crashes that contain `microtex::ArrayFormula::insertAtomIntoCol` in their Stacktrace, that end up crashing in libstdc++ `std::__shared_ptr<microtex::Atom, (__gnu_cxx::_Lock_policy)2>::__shared_ptr` function. I have yet to figure out what exactly causes this, as this appears to be in the end also a nullptr deref, however no nullptr is ever passed into `sptr`.
For example, `\begin{cases}&{}\\\\` causes this, any ideas?