### PR TITLE
Qt: Save as PDF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ if (MSVC)
     target_link_libraries(LaTeX PRIVATE tinyxml2::tinyxml2)
 else ()
     find_package(PkgConfig REQUIRED)
-    pkg_check_modules(tinyxml2 REQUIRED IMPORTED_TARGET tinyxml2)
+#   pkg_check_modules(tinyxml2 REQUIRED IMPORTED_TARGET tinyxml2)
     target_link_libraries(LaTeX PRIVATE tinyxml2)
 endif ()
 
@@ -151,8 +151,8 @@ target_include_directories(LaTeX PUBLIC src)
 if (QT)
     message(STATUS, "Cross platform build using Qt")
     target_compile_definitions(LaTeX PUBLIC -DBUILD_QT)
-    find_package(QT NAMES Qt6 Qt5 COMPONENTS Gui Widgets REQUIRED)
-    find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Gui Widgets REQUIRED)
+    find_package(QT NAMES Qt6 Qt5 COMPONENTS Gui Widgets PrintSupport REQUIRED)
+    find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Gui Widgets PrintSupport REQUIRED)
     target_sources(LaTeX PRIVATE
             src/platform/qt/graphic_qt.cpp
             )
@@ -165,7 +165,9 @@ if (QT)
             src/samples/qt_main.cpp
             )
     target_link_libraries(LaTeXQtSample PRIVATE
-            Qt${QT_VERSION_MAJOR}::Widgets LaTeX)
+            Qt${QT_VERSION_MAJOR}::Widgets
+            Qt${QT_VERSION_MAJOR}::PrintSupport
+            LaTeX)
     set_target_properties(LaTeXQtSample PROPERTIES OUTPUT_NAME LaTeX)
     set_target_properties(LaTeXQtSample PROPERTIES AUTOMOC ON)
 elseif (SKIA)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ if (MSVC)
     target_link_libraries(LaTeX PRIVATE tinyxml2::tinyxml2)
 else ()
     find_package(PkgConfig REQUIRED)
-#   pkg_check_modules(tinyxml2 REQUIRED IMPORTED_TARGET tinyxml2)
+    pkg_check_modules(tinyxml2 REQUIRED IMPORTED_TARGET tinyxml2)
     target_link_libraries(LaTeX PRIVATE tinyxml2)
 endif ()
 

--- a/src/samples/qt_mainwindow.h
+++ b/src/samples/qt_mainwindow.h
@@ -21,6 +21,9 @@ class MainWindow : public QWidget
 public:
   MainWindow(QWidget* parent=nullptr);
 
+  //! \return file name, or empty string on cancel
+  QString saveAsDialog();
+
 protected slots:
   void nextClicked();
   void renderClicked();

--- a/src/samples/qt_texwidget.cpp
+++ b/src/samples/qt_texwidget.cpp
@@ -2,6 +2,9 @@
 
 #include "qt_texwidget.h"
 
+#include <QPrinter>
+#include <QScreen>
+
 using namespace tex;
 
 TeXWidget::TeXWidget(QWidget* parent, float text_size)
@@ -71,6 +74,29 @@ void TeXWidget::paintEvent(QPaintEvent* event)
     Graphics2D_qt g2(&painter);
     _render->draw(g2, _padding, _padding);
   }
+}
+
+void TeXWidget::savePDF(QString fileName)
+{
+    QPrinter printer;
+    printer.setOutputFormat(QPrinter::PdfFormat);
+    //printer.setPaperSize(QPrinter::A4); ?
+    printer.setOutputFileName(fileName);
+    printer.setFullPage(true);
+    printer.setFontEmbeddingEnabled(true);
+
+    qreal dpix = screen()->logicalDotsPerInchX();
+    qreal dpiy = screen()->logicalDotsPerInchY();
+
+    QSize pointSize ((int)getRenderWidth()*72.0/dpix, (int)getRenderHeight()*72.0/dpiy );
+    printer.setPageSize(QPageSize(pointSize, QPageSize::Point));
+
+    QPainter painter(&printer);
+    painter.setRenderHint(QPainter::Antialiasing, true);
+    painter.setRenderHint(QPainter::TextAntialiasing, true);
+
+    tex::Graphics2D_qt g2(&painter);
+    _render->draw(g2, _padding, _padding);
 }
 
 

--- a/src/samples/qt_texwidget.h
+++ b/src/samples/qt_texwidget.h
@@ -24,6 +24,10 @@ class TeXWidget : public QWidget
   int getRenderHeight();
   void paintEvent(QPaintEvent* event);
 
+  //! save as PDF file with embedded fonts;
+  //! page size is taken from render width and height
+  void savePDF(QString fileName);
+
  private:
   tex::TeXRender* _render;
   float _text_size;


### PR DESCRIPTION
With little effort, Qt can write perfectly nice PDF files. Fonts are embedded automatically.
I think this is a neat alternative to SVG printing.

---

(there is also a class called QSvgGenerator, but it is less useful because it can not embed fonts, or convert text into paths).

---
(btw, I didn't manage Skia integration. Latest Skia code seems to have diverged too far).

