### PR TITLE
Do not depend on bool being one byte

### DIFF
--- a/lib/otf/clm.cpp
+++ b/lib/otf/clm.cpp
@@ -120,7 +120,7 @@ public:
 void CLMReader::readMeta(Otf& font, BinaryReader& reader) {
   font._name = std::string(reader.readString());
   font._family = std::string(reader.readString());
-  font._isMathFont = reader.read<bool>();
+  font._isMathFont = reader.read<u8>();
   font._style = reader.read<u16>();
   font._em = reader.read<u16>();
   font._xHeight = reader.read<u16>();
@@ -225,7 +225,7 @@ Variants* CLMReader::readVariants(BinaryReader& reader) {
 }
 
 GlyphAssembly* CLMReader::readGlyphAssembly(BinaryReader& reader) {
-  const bool isPresent = reader.read<bool>();
+  const bool isPresent = reader.read<u8>();
   if (!isPresent) return nullptr;
   const u16 partCount = reader.read<u16>();
   auto* assembly = new GlyphAssembly(partCount);


### PR DESCRIPTION
The size of the bool data type is implementation-defined. I'm on a platform where gcc defaults to bool being 4 bytes, not 1. Thus we should use u8 here instead of bool to make sure the code is portable.